### PR TITLE
Java buildpack compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: minimal
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+TESTFILES := $(wildcard tests/*)
+test:
+	@for test in ${TESTFILES}; do "$$test"; done

--- a/bin/supply
+++ b/bin/supply
@@ -20,11 +20,23 @@ else
   JSON_CONFIG="$(./yq r "$APP_DIR/$CONFIG" -j)"
 fi
 
-mkdir -p "$DEPS_DIR/$IDX/profile.d"
+profile_dir="$DEPS_DIR/$IDX/profile.d"
+mkdir -p "$profile_dir"
+profile_file="$profile_dir/$IDX-mapped-env-vars.sh"
+
 for var in $(echo "$JSON_CONFIG" | jq -r '.env_vars | keys[]'); do
   selector="$(echo "$JSON_CONFIG" | jq -r ".env_vars.$var")"
-  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> "$DEPS_DIR/$IDX/profile.d/$IDX-mapped-env-vars.sh"
+  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> "$profile_file"
 done
+
+# HACK:
+# The java buildpack doesn't support loading environment variables from .profile.d in deps/ID/profile.d
+# So we also have to copy it to app/.profile.d
+#
+# See https://github.com/cloudfoundry/java-buildpack/issues/563#issuecomment-452437417
+# and https://github.com/cyberark/cloudfoundry-conjur-buildpack/blob/31f4cbef/bin/supply#L96-L115
+mkdir -p "$APP_DIR/.profile.d/"
+cp "$profile_file" "$APP_DIR/.profile.d/"
 
 echo "$log_prefix Done."
 exit 0

--- a/bin/supply
+++ b/bin/supply
@@ -15,7 +15,7 @@ if [[ $CONFIG =~ .json ]]; then
   JSON_CONFIG="$(< "$APP_DIR/$CONFIG")"
 else
   echo "$log_prefix Downloading yq"
-  curl -L https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64 -o yq
+  curl --silent --location https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64 -o yq
   chmod +x yq
   JSON_CONFIG="$(./yq r "$APP_DIR/$CONFIG" -j)"
 fi

--- a/bin/supply
+++ b/bin/supply
@@ -1,30 +1,31 @@
 #!/bin/bash
-# bin/compile <build-dir> <cache-dir>
 
-set -ex
+set -e
 
 APP_DIR=$1
-CACHE_DIR=$2
 DEPS_DIR=$3
 IDX=$4
 
-CONFIG=${ENV_MAP_BP_CONFIG:-"env-map.yml"}
-echo "Creating profile.d file using $CONFIG"
+log_prefix='-----> [env-map-buildpack]'
 
-if [[ $CONFIG =~ ".json" ]]; then
-  JSON_CONFIG="$(cat $APP_DIR/$CONFIG)"
+CONFIG=${ENV_MAP_BP_CONFIG:-"env-map.yml"}
+echo "$log_prefix Creating profile.d file using $CONFIG"
+
+if [[ $CONFIG =~ .json ]]; then
+  JSON_CONFIG="$(< "$APP_DIR/$CONFIG")"
 else
-  echo "Downloading yq"
+  echo "$log_prefix Downloading yq"
   curl -L https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64 -o yq
   chmod +x yq
-  JSON_CONFIG="$(./yq r $APP_DIR/$CONFIG -j)"
+  JSON_CONFIG="$(./yq r "$APP_DIR/$CONFIG" -j)"
 fi
 
-mkdir -p $DEPS_DIR/$IDX/profile.d
+mkdir -p "$DEPS_DIR/$IDX/profile.d"
 for var in $(echo "$JSON_CONFIG" | jq -r '.env_vars | keys[]'); do
-	selector="$(echo "$JSON_CONFIG" | jq -r ".env_vars.$var")"
-  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> $DEPS_DIR/$IDX/profile.d/$IDX-mapped-env-vars.sh
+  selector="$(echo "$JSON_CONFIG" | jq -r ".env_vars.$var")"
+  echo "export $var=\"\$(echo \$VCAP_SERVICES | jq -r '$selector')\"" >> "$DEPS_DIR/$IDX/profile.d/$IDX-mapped-env-vars.sh"
 done
 
-echo "-----> Done."
+echo "$log_prefix Done."
 exit 0
+

--- a/tests/supply
+++ b/tests/supply
@@ -19,25 +19,30 @@ function test_creates_profile_d {
   echo '{"env_vars":{"KEY": "VALUE"}}' > app/env-map.json
   export ENV_MAP_BP_CONFIG="env-map.json"
 
-  "$supply" ./app IGNORED ./deps 0 &> /dev/null
+  "$supply" ./app IGNORED ./deps 0 #&> /dev/null
 
-  local file_path=./deps/0/profile.d/0-mapped-env-vars.sh
-  if [[ ! -f "$file_path" ]]; then
-    >&2 echo "FAIL: expected to find a mapping script in profile.d"
-    >&2 echo "Files were:"
-    >&2 tree
-    exit 1
-  fi
+  local file_paths=(
+    ./deps/0/profile.d/0-mapped-env-vars.sh
+    ./app/.profile.d/0-mapped-env-vars.sh
+  )
+  for file_path in "${file_paths[@]}"; do
+    if [[ ! -f "$file_path" ]]; then
+      >&2 echo "FAIL: expected to find a mapping script in profile.d"
+      >&2 echo "Files were:"
+      >&2 tree
+      exit 1
+    fi
 
-  # shellcheck disable=SC2016
-  expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
+    # shellcheck disable=SC2016
+    expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
 
-  if ! grep -q -F "$expected" "$file_path"; then
-    >&2 echo "FAIL: expected to find an export of '$expected'"
-    >&2 echo "Instead, found:"
-    >&2 cat "$file_path"
-    exit 1
-  fi
+    if ! grep -q -F "$expected" "$file_path"; then
+      >&2 echo "FAIL: expected to find an export of '$expected'"
+      >&2 echo "Instead, found:"
+      >&2 cat "$file_path"
+      exit 1
+    fi
+  done
 
   echo "PASS"
 }

--- a/tests/supply
+++ b/tests/supply
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+supply=$(cd "$(dirname "$0")/../bin" && pwd)/supply
+
+function use_tmp_environment {
+  local name=$1
+  cd "$(mktemp -d -t "$name.XXXXX")"
+  mkdir app
+  mkdir -p deps/0
+}
+
+function test_creates_profile_d {
+  echo "TEST: should create profile.d and add a script exporting variables"
+
+  use_tmp_environment 'env-map-buildpack-test-creates-profile-d'
+
+  echo '{"env_vars":{"KEY": "VALUE"}}' > app/env-map.json
+  export ENV_MAP_BP_CONFIG="env-map.json"
+
+  "$supply" ./app IGNORED ./deps 0 &> /dev/null
+
+  local file_path=./deps/0/profile.d/0-mapped-env-vars.sh
+  if [[ ! -f "$file_path" ]]; then
+    >&2 echo "FAIL: expected to find a mapping script in profile.d"
+    >&2 echo "Files were:"
+    >&2 tree
+    exit 1
+  fi
+
+  # shellcheck disable=SC2016
+  expected='export KEY="$(echo $VCAP_SERVICES | jq -r '"'VALUE'"')"'
+
+  if ! grep -q -F "$expected" "$file_path"; then
+    >&2 echo "FAIL: expected to find an export of '$expected'"
+    >&2 echo "Instead, found:"
+    >&2 cat "$file_path"
+    exit 1
+  fi
+
+  echo "PASS"
+}
+
+test_creates_profile_d
+


### PR DESCRIPTION
I've tested this manually with pay-connector (which is a java app) and it seems to work.

It's a bit gross having to do this for all buildpacks because we don't know whether it's going to be the java buildpack or not. Perhaps we should add a `ENV_MAP_BP_ENABLE_JAVA_HACK` flag or something to make it clear what it's doing?

What do you think?